### PR TITLE
Add hash method to use object keys to identify results

### DIFF
--- a/spec/hope.coffee
+++ b/spec/hope.coffee
@@ -74,6 +74,14 @@ describe "Module", ->
         if error then errorString = error
       expect(errorString).not.toEqual null
 
+  it "can dispatch error in multiple sync/async methods identified with a key", ->
+    Hope.hash(
+      'one': -> syncDouble 2
+      'two': -> syncDouble 1980
+      'three': -> syncDouble 3
+    ).then (errors, values) ->
+      expect(errors['two']).not.toEqual null
+
 
   it "can chain multiple sync/async methods", ->
     result = 14

--- a/spec/hope.html
+++ b/spec/hope.html
@@ -40,6 +40,20 @@
             console.error("[async] :", error, result);
         });
 
+        //HASH
+        var date = new Date();
+        Hope.join({
+            'one': function() {
+                return sync(1);
+            },
+            'two': function() {
+                return async(20, 1500);
+            }
+        }).then(
+            function(errors, values) {
+                console.error("[hash]  :", (new Date() - date) + "ms", errors, values);
+            }
+        );
 
         //JOIN
         var date = new Date();

--- a/src/hope.coffee
+++ b/src/hope.coffee
@@ -18,9 +18,38 @@
   ###
   Executes a bunch of asynchronous tasks together, returns a promise, and
   resolve that promise when all tasks are done.
+  @method   hash
+  @param    {object} Object with functions
+  ###
+  hash = (callbacks) ->
+    callbacks_count = Object.keys(callbacks).length
+    done_count = 0
+    promise = new Promise()
+    errors = {}
+    results = {}
+
+    notifier = (v) ->
+      (error, result) ->
+        done_count += 1
+        errors[v] = error
+        results[v] = result
+        promise.done errors, results if done_count is callbacks_count
+
+    i = 0
+    while i < callbacks_count
+      v = Object.keys(callbacks)[i]
+      callbacks[v]().then notifier(v)
+      i++
+    promise
+
+
+  ###
+  Executes a bunch of asynchronous tasks together, returns a promise, and
+  resolve that promise when all tasks are done.
   @method   join
   @param    {array} Array of functions
   ###
+
   join = (callbacks) ->
     callbacks_count = callbacks.length
     done_count = 0
@@ -40,7 +69,6 @@
       callbacks[i]().then notifier(i)
       i++
     promise
-
 
   ###
   Executes a bunch of asynchronous tasks in sequence, passing to each function
@@ -108,6 +136,7 @@
   ###
   Hope =
     Promise : Promise
+    hash    : hash
     join    : join
     chain   : chain
     shield  : shield


### PR DESCRIPTION
It could be interesting, when you have multiple functions inside Hope.join to be able to identify them in the result.
