### PR TITLE
Return empty result when empty task is passed to Hope.join

### DIFF
--- a/src/hope.coffee
+++ b/src/hope.coffee
@@ -64,6 +64,8 @@
         results[i] = result
         promise.done errors, results if done_count is callbacks_count
 
+    promise.done errors, results if callbacks_count is 0
+
     i = 0
     while i < callbacks_count
       callbacks[i]().then notifier(i)


### PR DESCRIPTION
Sometimes the tasks array passed to _Hope.join_ could be empty. Currently the promise isn't resolved correctly.

With this fix, the promise is resolved returning and empty error and result array.

The functionality would be the same that you get with other libraries like _async_.
